### PR TITLE
website: Supress jekyll behaviour on gh-pages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
               git init -b gh-pages
               git remote add origin git@github.com:Plutonomicon/plutonomicon.git
               cp -r ${self.website}/* .
-              git add .
+              git add . .nojekyll
               git commit -m "Deploy to gh-pages"
               git push -f origin gh-pages:gh-pages
             '';


### PR DESCRIPTION
Emanote generates this file, but CI didn't commit it to git.

cf. https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/

This is perhaps why static sites including fonts return 404.