### PR TITLE
Add vscode default settings & exts

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": [
+		"yzhang.markdown-all-in-one",
+		"svsool.markdown-memo",
+		"houkanshan.vscode-markdown-footnote"
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+    // Avoid having to explicitly save notes
+    "files.autoSave": "afterDelay",
+    // Minimap is not useful for Markdown notes
+    "editor.minimap.enabled": false,
+    // Generally note files are not opened in duplicate tabs.
+    // This also enables you to navigate to already open note in other split pane
+    "workbench.editor.revealIfOpen": true,
+    // "editor.formatOnSave": true,
+    "editor.wordWrap": "on",
+    "files.autoSaveDelay": 500,
+    "pasteImage.insertPattern": "![[${imageFilePath}]]"
+    // If use Git, these might be interesting:
+    // "git.autofetch": true,
+    // "git.postCommitCommand": "push"
+}


### PR DESCRIPTION
Based on https://github.com/srid/emanote-template

Basically this allows people to open this repo in VSCode and get everything setup for editing Markdown files.