### PR TITLE
Update /fundamentals to modern Plutus information and fix broken links

### DIFF
--- a/fundamentals.md
+++ b/fundamentals.md
@@ -32,7 +32,7 @@ The functionality you want is then expressed through what kind of transactions y
 
 In a distributed ledger, size is an expensive resource. As such, transactions are limited in size based on the `max_tx_size` protocol parameter. The current limit is 16 KiB, but this is subject to change.
 
-Previously, any validator that needed to run in a transaction had to be stored in taht transaction, meaning that scripts could quickly cause the transaction to go over the size limit.
+Previously, any validator that needed to run in a transaction had to be stored in that transaction, meaning that scripts could quickly cause the transaction to go over the size limit.
 
 This is no longer the case, with the introduction of **Reference Scripts** which were proposed in [CIP-33](https://cips.cardano.org/cip/CIP-33). Now, scripts can be stored in a UTxO, and that UTxO can be referenced by a transaction, greatly decreasing transaction size.
 
@@ -88,11 +88,11 @@ There are rules for whether a transaction can consume a UTxO.
 
 Each UTxO is associated with either a script (validator) or a public key hash.
 
-If it's a public key hash, then a transaction can only consume the UTxO if it contains a signature by the public key in question.
+If its a public key hash, then a transaction can only consume the UTxO if it contains a signature by the public key in question.
 
 If it is a validator, then the validator will be run with three arguments, in the following order:
 
-- The datum, which either has it's hash or the full datum attched to the UTxO.
+- The datum, which either has its hash or the full datum attached to the UTxO.
 - The redeemer, which is attached to the **consuming** transaction.
 - The script context, which contains the consuming transaction itself in addition to some auxiliary information.
 

--- a/fundamentals.md
+++ b/fundamentals.md
@@ -6,39 +6,43 @@ There are two big parts to Cardano: The consensus algorithm and ledger model. Wh
 
 ## Resources
 
-NB: We are currently in Alonzo.
+NB: We are currently in the Babbage ledger era.
 
-1. [https://staging.plutus.iohkdev.io/doc/haddock/plutus-ledger-api/html/Plutus-V2-Ledger-Contexts.html#t:TxInfo](https://staging.plutus.iohkdev.io/doc/haddock/plutus-ledger-api/html/Plutus-V2-Ledger-Contexts.html#t:TxInfo)
-1. [https://iohk.io/en/research/library/papers/native-custom-tokens-in-the-extended-utxo-model/](https://iohk.io/en/research/library/papers/native-custom-tokens-in-the-extended-utxo-model/)
-1. [https://github.com/input-output-hk/cardano-ledger/tree/master/eras/alonzo/test-suite/cddl-files](https://github.com/input-output-hk/cardano-ledger/tree/master/eras/alonzo/test-suite/cddl-files)
-1. [https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/specs.alonzo-ledger/latest/download-by-type/doc-pdf/alonzo-changes](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/specs.alonzo-ledger/latest/download-by-type/doc-pdf/alonzo-changes)
-1. [https://hydra.iohk.io/job/Cardano/cardano-node/cardano-deployment/latest-finished/download/1/index.html](https://hydra.iohk.io/job/Cardano/cardano-node/cardano-deployment/latest-finished/download/1/index.html)
-1. [https://plutus-apps.readthedocs.io/en/latest/](https://plutus-apps.readthedocs.io/en/latest/)
-1. [https://github.com/input-output-hk/plutus/blob/master/plutus-core/cost-model/CostModelGeneration.md](https://github.com/input-output-hk/plutus/blob/master/plutus-core/cost-model/CostModelGeneration.md)
-1. [https://github.com/input-output-hk/plutus/blob/master/plutus-core/cost-model/data/builtinCostModel.json](https://github.com/input-output-hk/plutus/blob/master/plutus-core/cost-model/data/builtinCostModel.json)
-1. [https://staging.plutus.iohkdev.io/doc/haddock/plutus-tx/html/PlutusTx-Builtins-Internal.html](https://staging.plutus.iohkdev.io/doc/haddock/plutus-tx/html/PlutusTx-Builtins-Internal.html)
+1. [https://intersectmbo.github.io/plutus-apps/main/plutus-ledger-api/html/Plutus-V2-Ledger-Contexts.html#t:TxInfo](https://intersectmbo.github.io/plutus-apps/main/plutus-ledger-api/html/Plutus-V2-Ledger-Contexts.html#t:TxInfo)
+2. [https://iohk.io/en/research/library/papers/native-custom-tokens-in-the-extended-UTxO-model/](https://iohk.io/en/research/library/papers/native-custom-tokens-in-the-extended-UTxO-model/)
+3. [https://github.com/IntersectMBO/cardano-ledger/tree/master/eras/babbage/impl/cddl-files](https://github.com/IntersectMBO/cardano-ledger/tree/master/eras/babbage/impl/cddl-files)
+4. [https://github.com/input-output-hk/cardano-ledger/releases/latest/download/babbage-ledger.pdf](https://github.com/input-output-hk/cardano-ledger/releases/latest/download/babbage-ledger.pdf)
+5. [https://github.com/IntersectMBO/cardano-node#overview-of-the-cardano-node-repository](https://github.com/IntersectMBO/cardano-node#overview-of-the-cardano-node-repository)
+6. [https://plutus-apps.readthedocs.io/en/latest/](https://plutus-apps.readthedocs.io/en/latest/)
+7. [https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/CostModelGeneration.md](https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/CostModelGeneration.md)
+8. [https://github.com/IntersectMBO/plutus/tree/master/plutus-core/cost-model/data](https://github.com/IntersectMBO/plutus/tree/master/plutus-core/cost-model/data)
+9. [https://www.doitwithlovelace.io/haddock/plutus-tx/html/PlutusTx-Builtins.html](https://www.doitwithlovelace.io/haddock/plutus-tx/html/PlutusTx-Builtins.html)
 
 ## Overview
 
-Essentially, the ledger is a list of blocks, where each block is a list of transactions. Transactions have inputs, outputs, and some associated metadata. Outputs can only be consumed once, and only by transactions in a future block. Therefore we refer to unconsumed outputs (available outputs) as UTXOs. The transactions form a directed acyclic graph, with a vertex for each transaction, and an edge from each output to its corresponding input.
+Essentially, the ledger is a list of blocks, where each block is a list of transactions. Transactions have inputs, outputs, and some associated metadata. Outputs can only be consumed once, and only by transactions in a future block. Therefore we refer to unconsumed outputs (available outputs) as UTxOs. The transactions form a directed acyclic graph, with a vertex for each transaction, and an edge from each output to its corresponding input.
 
 ## Scripts
 
 Scripts in Cardano can either fail or succeed, and can not cause any side effects. Concretely, it is essentially strictly evaluated untyped lambda calculus, with some extra built-in functions for handling on-chain data types (such as integers), and a built-in function for aborting the evaluation, `error`.
 
-The functionality you want is then expressed through what kind of transactions you allow consuming the UTXO.
+The functionality you want is then expressed through what kind of transactions you allow consuming the UTxO.
 
 ### Script sizes
 
-You should be very careful with how big you make your scripts. Scripts are currently stored in every transaction that consumes them, meaning that they will quickly cause you to go past the (current) transaction size 16 KiB limit. It depends on the structure of transaction but keep in mind that beside scripts there are other items (datums, redeemers, signature, etc) on Tx and we need to have space for that.
+In a distributed ledger, size is an expensive resource. As such, transactions are limited in size based on the `max_tx_size` protocol parameter. The current limit is 16 KiB, but this is subject to change.
 
+Previously, any validator that needed to run in a transaction had to be stored in taht transaction, meaning that scripts could quickly cause the transaction to go over the size limit.
 
+This is no longer the case, with the introduction of **Reference Scripts** which were proposed in [CIP-33](https://cips.cardano.org/cip/CIP-33). Now, scripts can be stored in a UTxO, and that UTxO can be referenced by a transaction, greatly decreasing transaction size.
 
-Note that we need to have some headroom on size because number of inputs is unpredictable and we should have some space for extra inputs and change that user pays back to own wallet.
+Keep in mind that while reference scripts have significantly helped, transactions also include other items (datums, redeemers, witnesses, etc.), so transaction size can still be a limiting factor in practice.
+
+Note that we need to have some headroom on size because number of inputs is unpredictable and we should have some space for extra inputs and change outputs that the user pays back to own wallet.
 
 ### Execution limits
 
-In addition to transaction sizes, scripts are also bounded by the amount of time and space they can use. The current limits (accessible in resource 5) are 10,000,000 `exUnitsMem` and 10,000,000,000 `exUnitsSteps`.
+In addition to transaction sizes, scripts are also bounded by the amount of time and space they can use. The current limits (as defined by the `max_tx_em_mem` and `max_tx_ex_steps` protocol parameters) are 14,000,000 `exUnitsMem` and 10,000,000,000 `exUnitsSteps`.
 
 The exact meaning of these are defined via cost model for Plutus scripts. The current costs for various parts of Plutus can be found in resources 8.
 
@@ -52,7 +56,7 @@ A script can always access its own hash at execution time.
 
 ### Boolean return
 
-While scripts may be "boolean" in nature, they do not actually return a Scott-encoded boolean. Scripts wrapped with `wrapValidator` and similar, are simply wrapped with a function `check` that calls `error` is the returned value is `False`.
+While scripts may be "boolean" in nature, they do not actually return a Scott-encoded boolean. Scripts wrapped with `wrapValidator` and similar, are simply wrapped with a function `check` that calls `error` if the returned value is `False`.
 
 ### Available built-ins
 
@@ -78,17 +82,17 @@ You can use `unsafeDataAsConstr :: BuiltinData -> BuiltinPair BuiltinInteger (Bu
 decode it. The integer will generally correspond to the index of the constructor, defined in the call to
 `PlutusTx.IsData.makeIsDataIndexed`. The arguments passed to the constructor are contained in the list.
 
-## UTXOs (unconsumed transaction outputs)
+## UTxO (Unspent Transaction Outputs)
 
-There are rules for whether a transaction can consume a UTXO.
+There are rules for whether a transaction can consume a UTxO.
 
-Each UTXO is associated with either a script (validator) or a public key hash.
+Each UTxO is associated with either a script (validator) or a public key hash.
 
-If it's a public key hash, then a transaction can only consume the UTXO if it contains a signature by the public key in question.
+If it's a public key hash, then a transaction can only consume the UTxO if it contains a signature by the public key in question.
 
 If it is a validator, then the validator will be run with three arguments, in the following order:
 
-- The datum, the **hash** of which is attached to the UTXO.
+- The datum, which either has it's hash or the full datum attched to the UTxO.
 - The redeemer, which is attached to the **consuming** transaction.
 - The script context, which contains the consuming transaction itself in addition to some auxiliary information.
 
@@ -98,15 +102,15 @@ This is done by checking the consuming transaction's outputs, and asserting that
 
 ### Minimum Ada limit
 
-Each UTXO must have a specific minimum amount of Ada contained, dependent on the size of the UTXO. Currently, it is generally above 1 Ada.
+Each UTxO must have a specific minimum amount of Ada contained, dependent on the size of the UTxO. The actual minimum amount of ADA is determined by the `coins_per_UTxO_size` protocol parameter.
 
 ## Values
 
-Each UTXO can contain _value_, which are collections of tokens. Each token has a quantity, a name, and is associated with a minting policy hash (a script hash).
+Each UTxO can contain _value_, which are collections of tokens. Each token has a quantity, a name, and is associated with a minting policy hash (a script hash).
 
 Ada has an empty name, and the minting policy hash it is associated with is _empty_.
 
-Values, like UTXOs, can not be duplicated in general.
+Values, like UTxOs, can not be duplicated in general.
 
 ### Minting policies
 
@@ -127,7 +131,7 @@ The fees necessary for a transaction are known **ahead of time**. Fees will be c
 
 ### Transaction failure
 
-You might be wondering what happens if a transaction fails. It is after all very common for a transaction to fail. If we model some global state on the ledger through a global "state machine", then there can not be two transactions that consume this UTXO in the same block. In such a case, one of the transactions will be rejected and fail.
+You might be wondering what happens if a transaction fails. It is after all very common for a transaction to fail. If we model some global state on the ledger through a global "state machine", then there can not be two transactions that consume this UTxO in the same block. In such a case, one of the transactions will be rejected and fail.
 
 Transaction failure in Cardano is split up into 2 parts, general failure and script failure.
 
@@ -135,16 +139,16 @@ Script failure is when the scripts fail (i.e. they call `error`), and in such a 
 
 The collateral fee is higher than the standard fee, and exists in order to prevent DoSing the blockchain through submitting failing scripts that consume a lot of time and space (relatively).
 
-If the transaction fails due to other reasons, for example input unavailability, then no collateral fee nor standard fee will be paid, ensuring that you lose nothing due to UTXO contention.
+If the transaction fails due to other reasons, for example input unavailability, then no collateral fee nor standard fee will be paid, ensuring that you lose nothing due to UTxO contention.
 
 ## Datums and datum hashes
 
-UTXOs do **not** contain the datum itself. They only contain the hash. This distinction is very important, as a transaction may not actually contain the datum that corresponds to that hash. A transaction contains a mapping from input and output datum hashes to datums in `txInfoData`. Though the name says "data", AFAIK, it is restricted to the hashes of the datums in the inputs and outputs of a transaction unfortunately.
+Before the Vasil Hard Fork, UTxOs could not contain the datum itself, only the hash of the daum. However, the Vasil Hard Fork introduced [Inline Datums](https://cips.cardano.org/cip/CIP-32), allowing UTxOs to contain the full datum itself.
 
-The datums for the inputs are always contained in `txInfoData`. Anything else may not be present. If you in your script depend on the datum for an output being available, you must make sure when submitting the transaction that you include the datum in `txInfoData`. If it isn't included, the worst thing that can happen is that the transaction fails, so it is not a huge worry.
+If an input or an output includes an Inline Datum, then the datum itself is available in the relevant `TxOut` data.
+
+However, if only the datum hash is included, the datum itself may or may not be available to the script. A transaction contains a mapping from datum hashes to datums in `txInfoData`. The datums for the inputs are always contained in `txInfoData`. However, the same is not true for datums for the outputs. If you in your script depend on the datum for an output being available, you must make sure when submitting the transaction that you include the datum in txInfoData. If it isn’t included, the worst thing that can happen is that the transaction fails, so it is not a huge worry.
 
 ### Calculating hashes on-chain
 
-This is currently infeasible, as there is no built-in function to do so. You must manually serialize the datum into CBOR as a `BuiltinByteString`, then hash that using `sha2_256`. In the future, there will be a way to hash data on chain:
-
-- [https://github.com/input-output-hk/plutus/issues/4167](https://github.com/input-output-hk/plutus/issues/4167)
+Plutus provides built-in functions for calculating hashes, such ash `sha2_256`, `sha3_256` and `blake2b_256`. However, all of these functions are take a `BuiltinByteString` as input, and not a `BuiltinData`. Previously, you had to manually serialize your `BuiltinData` to CBOR. However, thanks to [CIP-42](https://cips.cardano.org/cip/CIP-42), there is a function `serialiseData` that serializes a `BuiltinData` into CBOR as a `BuiltinByteString`.


### PR DESCRIPTION
The Plutonomicon has very useful information, but much of it is outdated and many of the external links are broken. This PR updates the fundamentals information and links to match the current state of the Cardano blockchain and external resources.